### PR TITLE
13 alt value shapes

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,3 +2,4 @@ pytest >= 6.2
 black >= 21.6b0
 pytest-black >= 0.3.12
 setuptools >= 74
+pyinstaller >= 5.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tap2shacl"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 description = "DC TAP to SHACL converter."
 readme = "README.MD"
 authors = [{name = "Phil Barker", email="phil.barker@pjjk.co.uk"}]
@@ -32,6 +32,7 @@ dev = [
     "pytest >= 6.2",
     "black >= 21.6b0",
     "pytest-black >= 0.3.12",
+    "pyinstaller >= 5.4"
 ]
 
 [project.urls]

--- a/src/tap2ap/tap2apConverter.py
+++ b/src/tap2ap/tap2apConverter.py
@@ -158,21 +158,28 @@ class TAP2APConverter:
             raise TypeError(msg)
 
     def convert_valueConstraints(self, constraints, ps):
-        """Convert a string of constraints into separate items and add them as values of the `valueConstraints` property of statementTemplate."""
-        if type(constraints) is str:
+        """Convert a constraint or list of constraints into separate items and add them as values of the `valueConstraints` property of statementTemplate."""
+        # To do: dctap is now providing integer values for some constraints, cludgy patch included, but need to check details of what dctap is doing.
+        if isinstance(constraints, str):
             for constraint in re.split(constraint_splitters, constraints):
                 ps.add_valueConstraint(constraint)
+        elif isinstance(constraints, int):
+            constraint = str(constraints)
+            ps.add_valueConstraint(constraint)
         elif type(constraints) is list:
             for constraint in constraints:
-                if type(constraint) is str:
+                if isinstance(constraint, str):
+                    ps.add_valueConstraint(constraint)
+                elif isinstance(constraint, int):
+                    constraint = str(constraint)
                     ps.add_valueConstraint(constraint)
                 else:
                     print(constraint)
-                    msg = "Value for constraint must be a string."
+                    msg = "Value for constraint must be a string or integer."
                     raise TypeError(msg)
         else:
             print(constraints)
-            msg = "Value for constraints must be a string or a list."
+            msg = "Value for constraints must be a string, integer or a list."
             raise TypeError(msg)
 
     def convert_valueConstraintType(self, constrTypeStr, ps):

--- a/src/tap2ap/tap2apConverter.py
+++ b/src/tap2ap/tap2apConverter.py
@@ -160,21 +160,22 @@ class TAP2APConverter:
     def convert_valueConstraints(self, constraints, ps):
         """Convert a constraint or list of constraints into separate items and add them as values of the `valueConstraints` property of statementTemplate."""
         # To do: dctap is now providing integer values for some constraints, cludgy patch included, but need to check details of what dctap is doing.
-        if isinstance(constraints, str):
+        if type(constraints) is str:
             for constraint in re.split(constraint_splitters, constraints):
                 ps.add_valueConstraint(constraint)
-        elif isinstance(constraints, int):
+        elif type(constraints) is int:
             constraint = str(constraints)
             ps.add_valueConstraint(constraint)
         elif type(constraints) is list:
-            for constraint in constraints:
-                if isinstance(constraint, str):
-                    ps.add_valueConstraint(constraint)
-                elif isinstance(constraint, int):
-                    constraint = str(constraint)
+            for list_item in constraints:
+                if type(list_item) is str:
+                    for constraint in re.split(constraint_splitters, list_item):
+                        ps.add_valueConstraint(constraint)
+                elif type(list_item) is int:
+                    constraint = str(list_item)
                     ps.add_valueConstraint(constraint)
                 else:
-                    print(constraint)
+                    print(list_item)
                     msg = "Value for constraint must be a string or integer."
                     raise TypeError(msg)
         else:

--- a/src/tap2ap/tap2apConverter.py
+++ b/src/tap2ap/tap2apConverter.py
@@ -29,9 +29,11 @@ class TAP2APConverter:
 
     def load_tap(self, tap_fname, config_fname):
         """Load TAP data from file."""
-        self.tap["config_dict"] = get_config(nondefault_configfile_name = config_fname)
+        self.tap["config_dict"] = get_config(nondefault_configfile_name=config_fname)
         with open(tap_fname, "r") as csv_fileObj:
-            csvreader_output = csvreader( open_csvfile_obj=csv_fileObj, config_dict=self.tap["config_dict"])
+            csvreader_output = csvreader(
+                open_csvfile_obj=csv_fileObj, config_dict=self.tap["config_dict"]
+            )
             self.tap["shapes_dict"] = csvreader_output
             self.tap["warnings_dict"] = csvreader_output["warnings"]
 
@@ -230,7 +232,7 @@ class TAP2APConverter:
                         self.ap.add_namespace(prefix[:-1], prefixes[prefix])
                     else:
                         self.ap.add_namespace(prefix, prefixes[prefix])
-                else: # no prefix
+                else:  # no prefix
                     self.ap.add_namespace("default", prefixes[prefix])
         elif source == "csv":
             self.ap.load_namespaces(fname)

--- a/src/tap2shacl.py
+++ b/src/tap2shacl.py
@@ -2,6 +2,7 @@
 from tap2shacl import TAP2SHACLConverter, TAP2APConverter, AP2SHACLConverter
 from tap2shacl.parseArguments import parse_arguments
 
+
 def main():
     args = parse_arguments()
     print(args.tapFileName)
@@ -11,6 +12,7 @@ def main():
     c.convertAP2SHACL()
     #    c.dump_ap()
     c.dump_shacl(args.outputFileName)
+
 
 if __name__ == "__main__":
     main()

--- a/src/tap2shacl/__main__.py
+++ b/src/tap2shacl/__main__.py
@@ -2,6 +2,7 @@
 from tap2shacl import TAP2SHACLConverter, TAP2APConverter, AP2SHACLConverter
 from tap2shacl.parseArguments import parse_arguments
 
+
 def main():
     args = parse_arguments()
     print(args.tapFileName)
@@ -11,6 +12,7 @@ def main():
     c.convertAP2SHACL()
     #    c.dump_ap()
     c.dump_shacl(args.outputFileName)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/ap2shacl/test_ap2shaclConverter.py
+++ b/tests/ap2shacl/test_ap2shaclConverter.py
@@ -252,7 +252,7 @@ def address_ps():
             (BASE.personAddress, SH.path, SDO.address),
             (BASE.personAddress, SH.name, Literal("Address", lang="en")),
             (BASE.personAddress, SH.nodeKind, SH.BlankNodeOrIRI),
-#            (BASE.personAddress, SH.node, BASE.Address),
+            #            (BASE.personAddress, SH.node, BASE.Address),
             (BASE.personAddress, SH.severity, SH.Warning),
         ]
     )
@@ -342,7 +342,10 @@ def address_shapeInfo():
     shapeInfo = ShapeInfo(
         label={"en": "Address shape"},
         comment={"en": "A shape for tests"},
-        targets={"ObjectsOf": ["schema:address", "schema:location"], "class": ["schema:PostalAddress"]},
+        targets={
+            "ObjectsOf": ["schema:address", "schema:location"],
+            "class": ["schema:PostalAddress"],
+        },
         mandatory=False,
         ignoreProps=[],
         severity="Warning",
@@ -353,7 +356,7 @@ def address_shapeInfo():
             (BASE.Address, SH.name, Literal("Address shape", lang="en")),
             (BASE.Address, SH.description, Literal("A shape for tests", lang="en")),
             (BASE.Address, SH.targetObjectsOf, SDO.address),
-            (BASE.Address, SH.targetObjectsOf, SDO.location)
+            (BASE.Address, SH.targetObjectsOf, SDO.location),
         ]
     )
     return shapeInfo

--- a/tests/ap2shacl/test_ap2shaclConverter.py
+++ b/tests/ap2shacl/test_ap2shaclConverter.py
@@ -243,6 +243,7 @@ def address_ps():
     ps.add_valueNodeType("iri")
     ps.add_valueNodeType("BNode")
     ps.add_valueShape("#Address")
+    ps.add_valueShape("#Person")
     ps.add_severity("Warning")
     expected_triples.extend(
         [
@@ -251,10 +252,11 @@ def address_ps():
             (BASE.personAddress, SH.path, SDO.address),
             (BASE.personAddress, SH.name, Literal("Address", lang="en")),
             (BASE.personAddress, SH.nodeKind, SH.BlankNodeOrIRI),
-            (BASE.personAddress, SH.node, BASE.Address),
+#            (BASE.personAddress, SH.node, BASE.Address),
             (BASE.personAddress, SH.severity, SH.Warning),
         ]
     )
+    expected_ttl.append("sh:or ( [ sh:node <Address> ] [ sh:node <Person> ] ) ;")
     return ps
 
 

--- a/tests/tap2ap/test_loadTAP.py
+++ b/tests/tap2ap/test_loadTAP.py
@@ -14,7 +14,9 @@ shapesFileName = "tests/tap2ap/TestData/shapes.csv"
 def test_loadTAP():
     config_dict = get_config(nondefault_configfile_name=configFileName)
     with open(tapFileName, "r") as csv_fileObj:
-        csvreader_output = csvreader(open_csvfile_obj=csv_fileObj, config_dict=config_dict)
+        csvreader_output = csvreader(
+            open_csvfile_obj=csv_fileObj, config_dict=config_dict
+        )
     tapshapes_dict = csvreader_output
     warnings_dict = csvreader_output["warnings"]
     assert len(warnings_dict) == 2
@@ -25,7 +27,7 @@ def test_loadTAP():
     assert tapshapes_dict["shapes"][1]["shapeID"] == "AuthorShape"
     assert len(tapshapes_dict["shapes"][0]["statement_templates"]) == 4
     assert len(tapshapes_dict["shapes"][1]["statement_templates"]) == 3
-    sh0Constraints =  tapshapes_dict["shapes"][0]["statement_templates"]
+    sh0Constraints = tapshapes_dict["shapes"][0]["statement_templates"]
     sh1Constraints = tapshapes_dict["shapes"][1]["statement_templates"]
     assert sh0Constraints[0]["propertyID"] == "dct:title"
     assert sh0Constraints[1]["propertyID"] == "dct:creator"

--- a/tests/tap2ap/test_tap2apConverter.py
+++ b/tests/tap2ap/test_tap2apConverter.py
@@ -47,11 +47,15 @@ def test_convert_namespaces(test_Converter):
     print(c.ap.namespaces)
     assert c.ap.namespaces["default"] == "http://example.org/terms#"
 
+
 def test_load_AP_metadata(test_Converter):
     c = test_Converter
     assert c.ap.metadata == {}
     c.load_AP_Metadata(aboutFileName)
-    assert c.ap.metadata["url"] == "https://docs.google.com/spreadsheets/d/1Vr_x1ckpxG0v8oq7FGB2Qea8G3ESPFvUWK89H0wJH9w/edit#gid=424305041"
+    assert (
+        c.ap.metadata["url"]
+        == "https://docs.google.com/spreadsheets/d/1Vr_x1ckpxG0v8oq7FGB2Qea8G3ESPFvUWK89H0wJH9w/edit#gid=424305041"
+    )
     assert c.ap.metadata["title"] == "Simple book AP"
     assert c.ap.metadata["description"] == "Simple DC TAP for books"
     assert c.ap.metadata["author"] == "Phil Barker"
@@ -69,7 +73,10 @@ def test_load_shapeInfo(test_Converter):
     author_shapeInfo = c.ap.shapeInfo["AuthorShape"]
     assert book_shapeInfo.label == {"en": "Book"}
     assert author_shapeInfo.label == {"en": "Author"}
-    assert author_shapeInfo.targets == {"objectsof": ["dct:creator"], "class": ["sdo:Person"]}
+    assert author_shapeInfo.targets == {
+        "objectsof": ["dct:creator"],
+        "class": ["sdo:Person"],
+    }
     assert author_shapeInfo.closed == True
     assert author_shapeInfo.ignoreProps == ["rdf:type"]
     assert author_shapeInfo.mandatory == False
@@ -199,18 +206,25 @@ orgType:Business"""
     assert "orgType:Government" in ps.valueConstraints
     assert "orgType:HEI" in ps.valueConstraints
     vC = 2
-    with pytest.raises(TypeError) as e:
-        c.convert_valueConstraints(vC, ps)
-    assert str(e.value) == "Value for constraints must be a string or a list."
-    vC = [2]
-    with pytest.raises(TypeError) as e:
-        c.convert_valueConstraints(vC, ps)
-    assert str(e.value) == "Value for constraint must be a string."
-    vC = "\." # testing how escape chars are handled
     c.convert_valueConstraints(vC, ps)
-    print(ps.valueConstraints) # stored as \\.
+    assert "2" in ps.valueConstraints
+    #    vC = [3, 4]
+    #    c.convert_valueConstraints(vC, ps)
+    #    assert "3" in ps.valueConstraints
+    #    assert "4" in ps.valueConstraints
+    vC = 2.0
+    with pytest.raises(TypeError) as e:
+        c.convert_valueConstraints(vC, ps)
+    assert str(e.value) == "Value for constraints must be a string, integer or a list."
+    vC = [2.0]
+    with pytest.raises(TypeError) as e:
+        c.convert_valueConstraints(vC, ps)
+    assert str(e.value) == "Value for constraint must be a string or integer."
+    vC = "\."  # testing how escape chars are handled
+    c.convert_valueConstraints(vC, ps)
+    print(ps.valueConstraints)  # stored as \\.
     assert "\." in ps.valueConstraints  # passes
-    assert "\\." in ps.valueConstraints # also passes
+    assert "\\." in ps.valueConstraints  # also passes
 
 
 def test_convert_valueConstraintType(test_Converter):
@@ -229,8 +243,8 @@ def test_convert_shapes(test_Converter):
     c = test_Converter
     ps = StatementTemplate()
     shapes = "AddressShape,ContactShape"
-    addressShapeInfo = ShapeInfo(label= "Address")
-    contactShapeInfo = ShapeInfo(label= "Contact")
+    addressShapeInfo = ShapeInfo(label="Address")
+    contactShapeInfo = ShapeInfo(label="Contact")
     c.ap.add_shapeInfo("AddressShape", addressShapeInfo)
     c.ap.add_shapeInfo("ContactShape", contactShapeInfo)
     c.convert_valueShapes(shapes, ps)


### PR DESCRIPTION
Allows multiple value shapes, to be treated as alternatives.  Closes #13 

Also fixes issues with dctap providing constraints as lists, arising from resolution of issue #10 